### PR TITLE
Use absolute links for model viewer

### DIFF
--- a/cms.ar.xarchitecture.de/cms.ar.xarchitecture.de/static/ModelViewer/Index.html
+++ b/cms.ar.xarchitecture.de/cms.ar.xarchitecture.de/static/ModelViewer/Index.html
@@ -39,7 +39,7 @@
                 h2.textContent = asset.creator.name;
                 container.appendChild(h2);
                 const modelViewer = document.createElement("model-viewer");
-                modelViewer.src = asset.link.replace("http://luziffer.ddnss.de:8080/", "");
+                modelViewer.src = asset.link;
                 modelViewer.setAttribute("ar", "true");
                 container.appendChild(modelViewer);
                 document.body.appendChild(container);


### PR DESCRIPTION
This PR changes the `src` of the model viewer element to an absolute link.

This restores some functionality that got lost during various test builds.